### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index,:show]
   before_action :move_to_index, only: [:edit,:update]
-  before_action :item_set, only: [:show,:edit,:update]
+  before_action :item_set, only: [:show,:edit,:update,:destroy]
 
   def index
     @items = Item.order('created_at DESC')
@@ -32,7 +32,12 @@ class ItemsController < ApplicationController
     else
       render :edit
     end 
+  end
 
+  def destroy
+    if @item.destroy
+      redirect_to root_path
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index,:show]
-  before_action :move_to_index, only: [:edit,:update]
+  before_action :move_to_index, only: [:edit,:update,:destroy]
   before_action :item_set, only: [:show,:edit,:update,:destroy]
 
   def index
@@ -35,9 +35,8 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if @item.destroy
-      redirect_to root_path
-    end
+    @item.destroy
+    redirect_to root_path
   end
 
   private
@@ -52,7 +51,7 @@ class ItemsController < ApplicationController
 
   def move_to_index
     @item = Item.find(params[:id])
-    unless current_user.id == @user_id
+    unless current_user.id == @item.user_id
       redirect_to action: :index
     end
   end 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
 <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
    
      <% elsif user_signed_in?%>
     <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index' 
-  resources :items, only: [:index,:new, :create,:show,:edit,:update] do
+  resources :items do
   end
 end


### PR DESCRIPTION
#what
ルーティング設定
destroyアクション定義
view編集

#why
商品削除機能を実装するため

・ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/36788865f11ea7a3c787b74a224a867e